### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function TaserReporter(baseReporterDecorator, config, formatError) {
     this.onRunStart = onRunStart.bind(this);
     this.onBrowserStart = onBrowserStart.bind(this);
     this.onBrowserError = onBrowserError.bind(this);
+    this.onBrowserComplete = onBrowserComplete.bind(this);
     this.onSpecComplete = onSpecComplete.bind(this);
     this.onRunComplete = onRunComplete.bind(this);
 
@@ -49,6 +50,15 @@ function TaserReporter(baseReporterDecorator, config, formatError) {
 
     function onBrowserStart(browser, error) {
         makeBrowserRecord(browser.id, browser.name, browser.fullName);
+    }
+
+    function onBrowserComplete(browser) {
+        // This will get caught by `onBrowserError` in the new version of karma, but until then:
+        if (browser.lastResult.disconnected) {
+            makeBrowserRecord(browser.id, browser.name, browser.fullName);
+            errors[browser.id] = errors[browser.id] || [];
+            errors[browser.id].push('A test timed out after ' + browser.lastResult.totalTime + 'ms, likely due to an infinite loop or very high time complexity.');
+        }
     }
 
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // inject karma runner baseReporter and config
-TaserReporter.$inject = ['baseReporterDecorator', 'config'];
-function TaserReporter(baseReporterDecorator, config) {
+TaserReporter.$inject = ['baseReporterDecorator', 'config', 'formatError'];
+function TaserReporter(baseReporterDecorator, config, formatError) {
     // extend the base reporter
     baseReporterDecorator(this);
 
@@ -44,7 +44,7 @@ function TaserReporter(baseReporterDecorator, config) {
     function onBrowserError(browser, error) {
         makeBrowserRecord(browser.id, browser.name, browser.fullName);
         errors[browser.id] = errors[browser.id] || [];
-        errors[browser.id].push(error.replace(/\.js\?[a-f0-9]+\:/gi, '.js:'));
+        errors[browser.id].push(formatError(error));
     }
 
     function onBrowserStart(browser, error) {
@@ -67,14 +67,7 @@ function TaserReporter(baseReporterDecorator, config) {
         }
 
         if (testResult.log instanceof Array && testResult.log.length > 0) {
-            testResult.log = testResult.log.map(function(ea) {
-                if (ea.match('.js')) {
-                    ea = ea.replace(/\.js\?[a-f0-9]+\:/gi, '.js:'); // Clean out the hash to make it pretty.
-                } else {
-                    ea = ea.replace(/\n    at.+/gi, ''); // Remove browserify junk if we must. :/
-                }
-                return ea;
-            });
+            testResult.log = testResult.log.map(formatError);
         }
         
         // Add the test result to this browsers test results in its proper category


### PR DESCRIPTION
### Handle timeout errors

Karma is not handling timeout errors correctly causing an incorrect report. You might think a browser's disconnect would be handled by the `onBrowserError` method, but it doesn't in the current version of karma, and must be handled separately in `onBrowserComplete`

**Before**
(json)
![screen shot 2016-05-04 at 4 03 20 pm](https://cloud.githubusercontent.com/assets/6980359/15031972/e8192a5a-1211-11e6-9ab5-dae2fd4cd2c3.png)
(markdown)
![screen shot 2016-05-04 at 4 08 17 pm](https://cloud.githubusercontent.com/assets/6980359/15032064/7e720abc-1212-11e6-833a-7f07e963d226.png)

**After**
(json)
![screen shot 2016-05-04 at 4 02 42 pm](https://cloud.githubusercontent.com/assets/6980359/15031973/e95e0976-1211-11e6-937e-b0a10facd5c0.png)

(markdown)
![screen shot 2016-05-04 at 4 09 00 pm](https://cloud.githubusercontent.com/assets/6980359/15032075/95e6e92e-1212-11e6-8e0d-07514f2e88ff.png)
### Pretty error messages

Karma comes with an awesome `formatError` function that can be injected into any plugin. It handles source map support (important for ES6), resolving paths to given files, and much more.

**Before**
![screen shot 2016-05-04 at 2 18 15 pm](https://cloud.githubusercontent.com/assets/6980359/15029600/20ae2956-1203-11e6-8fbe-d720f8923ee1.png)
![screen shot 2016-05-04 at 2 18 31 pm](https://cloud.githubusercontent.com/assets/6980359/15029601/20afd738-1203-11e6-84ca-c33e337f3ba6.png)

**After**
![screen shot 2016-05-04 at 2 18 09 pm](https://cloud.githubusercontent.com/assets/6980359/15029604/273850bc-1203-11e6-8e77-41b73f552a48.png)
![screen shot 2016-05-04 at 2 18 27 pm](https://cloud.githubusercontent.com/assets/6980359/15029605/2738d0c8-1203-11e6-9741-fd6c51bdd9e3.png)
